### PR TITLE
column transformations now enforce preservation of column names

### DIFF
--- a/inst/tests/test-parse_mungepiece.r
+++ b/inst/tests/test-parse_mungepiece.r
@@ -34,7 +34,8 @@ test_that(paste0("it correctly parses training and predictions functions ",
   mp <- parse_mungepiece(list(c(imputer, 'Sepal.Length'),
                               c(restorer, 1, mean(iris[[1]]))))
   mp$run(mungeplane(iris))
-  plane <- mungeplane(data.frame(cbind(NA_real_)))
+  plane <- mungeplane(structure(data.frame(cbind(NA_real_)), names = names(iris)[1]))
+  
   mp$run(plane)
   expect_equal(mean(iris[[1]]), plane$data[1, 1],
     info = paste("plane$data should have had its one missing value imputed",


### PR DESCRIPTION
@irsal

Take a look at

https://github.com/robertzk/mungebitsTransformations/commit/75d9d3b1344772b98e63288ea2bc1c8027b7b274

and see if you understand why this fix was needed 
