### PR TITLE
Column Transformation changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mungebits
 Type: Package
 Title: mungebits (http://github.com/robertzk/mungebits)
 Description: Mungebits is a collection of data preparation functions
-Version: 0.3.12.2
+Version: 0.3.12.3
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mungebits
 Type: Package
 Title: mungebits (http://github.com/robertzk/mungebits)
 Description: Mungebits is a collection of data preparation functions
-Version: 0.3.12
+Version: 0.3.12.1
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mungebits
 Type: Package
 Title: mungebits (http://github.com/robertzk/mungebits)
 Description: Mungebits is a collection of data preparation functions
-Version: 0.3.12.1
+Version: 0.3.12.2
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/R/column_transformation.r
+++ b/R/column_transformation.r
@@ -51,6 +51,8 @@ column_transformation <- function(transformation, mutating = FALSE, named = FALS
           inputs$`*colnames*`
         else standard_cols
 
+      if(length(cols) == 0) return NULL
+
       if(exists('trained'))is_training <- !isTRUE(trained)
       else is_training <- TRUE
       # Trick to make assignment incredibly fast. Could screw up the

--- a/R/column_transformation.r
+++ b/R/column_transformation.r
@@ -51,7 +51,7 @@ column_transformation <- function(transformation, mutating = FALSE, named = FALS
           inputs$`*colnames*`
         else standard_cols
 
-      if(length(cols) == 0) return NULL
+      if(length(cols) == 0) return(NULL)
 
       if(exists('trained'))is_training <- !isTRUE(trained)
       else is_training <- TRUE

--- a/R/column_transformation.r
+++ b/R/column_transformation.r
@@ -81,15 +81,14 @@ column_transformation <- function(transformation, mutating = FALSE, named = FALS
         # scope (like in a mungebit). Afterwards, we exploit the fact that the
         # <<- operator never modifies local scope using
         #   inputs[[column_name]] <<- inputs
-	input_vec <- as.list(rep(NULL, length(inputs)))
+        input_vec <- NULL
+        input_vec[cols] <- list(NULL)
         has_in <- cols %in% names(inputs)
-	input_vec[has_in] <- inputs[cols]
+	input_vec[has_in] <- inputs[cols[has_in]]
+        
         dataframe[cols] <- lapply(1:length(cols), function(i, mycols, myinput_vec) {
           # If this is a prediction run and inputs already exists for this
           # column, use that, otherwise use NULL
-          # inputs <- if (exists('inputs') &&
-          #               column_name %in% names(inputs)) inputs[[column_name]]
-          #           else NULL
           column_name <- mycols[i]				  
           inputs <- myinput_vec[[i]]
           trained <- exists('trained') # TODO: (RK) Be more careful with this


### PR DESCRIPTION
Here's the column transformation changes we talked about.  The version incrementation was just for the benefit of my lockfile management.  I made up a new graph using median time instead of mean.  Took longer but is a bit cleaner.  Everything looks as we'd expect.  Slight overhead from the code additions, but much much faster when we assign to column level inputs.  Ooooo-rah
 
![alt text](http://i.imgur.com/dxvc1Xu.png "")


Used the identity function for the column transformation when not assigning to inputs.  For assigning to inputs I used a pretty normal-looking base-case:

```R
ct <- column_transformation(function(x) {
  if ('dummy' %in% names(inputs)) {
    if (inputs$dummy) x else x
  } else {
    inputs$dummy <<- FALSE
    x
  }}, mutating = TRUE)
```

It's still passing the tests you wrote originally, but I didn't write any additional ones.  Haven't finished going through mungebits2 yet.  Will update you when I do.